### PR TITLE
add: optional arguments to the CLI to display verbose description of listed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # linuxCheatsheet_CLI
 a Linux command cheatsheet CLI tool in Python
+
+Currently, the cheatsheet will focus on 5 commands, which are also the most common ones:
+
+1. ls
+
+2. cd
+
+3. pwd
+
+4. mkdir
+
+5. rm 
+
+As the project progresses, new commands will be appended to the cheatsheet CLI iteratively. 
+
+
+How to use this from the terminal:
+
+1. on running: python3 main.py commands from the terminal, a simple list of all the commands in the cheatsheet should be shown
+2. on running: python3 main.py commands --verbose or -v from the terminal, a list of all the commands in the cheatsheet is 
+to be shown with more details (like help text) 

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,32 @@
 import argparse
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='Linux CLI cheatsheet', description='display a linux command cheatsheet')
 parser.add_argument("commands", help="display all the available linux commands available in the linux cheatsheet")
 parser.add_argument("-v", "--verbose", action="store_true", help="increases output verbosity")
 args = parser.parse_args()
-if args.verbose:
-    argumentInput = args.commands
-    print("verbosity has been turned on")
 
+
+def display_all_commands() -> str:
+    commandsList = ['ls', 'cd', 'pwd', 'mkdir', 'rm']
+    print('\n'.join(commandsList))
+
+def display_all_commands_verbose() -> None:
+    commands_map = {
+        'ls': 'Used to list files and directories in the current directory',
+        'cd': 'Used to change directory',
+        'pwd': 'Used to print the present working directory',
+        'mkdir': 'Used to create a directory from the terminal',
+        'rm': 'Used to remove a file'
+    }
+    
+    for command in commands_map.items():
+        print(command)
+    
+    return
+
+if args.commands and not args.verbose:
+    display_all_commands()    
+
+if args.verbose:
+    display_all_commands_verbose()
+    print("Since verbosity was been turned on")


### PR DESCRIPTION
Adding optional arguments to the CLI to display verbose description if listed commands. 

To test, type: **python3 main.py commands --verbose** in the terminal from inside the src directory of the project

Assumptions made: _the user is using Python 3_